### PR TITLE
Separate some functionality from immutable trait

### DIFF
--- a/src/Traits/ImmutableValueObjectTrait.php
+++ b/src/Traits/ImmutableValueObjectTrait.php
@@ -7,6 +7,8 @@ use RuntimeException;
 
 trait ImmutableValueObjectTrait
 {
+    use ProtectedValueObjectTrait;
+
     /**
      * Hydrate the object with new values
      *
@@ -150,67 +152,5 @@ trait ImmutableValueObjectTrait
             }
             return $value;
         }, get_object_vars($this));
-    }
-
-    /**
-     * Checks if a property is defined in the object
-     *
-     * This will return `false` if the value is `null`! To check if a value
-     * exists in the object, use `has()`.
-     *
-     * @param string $key
-     *
-     * @return boolean
-     */
-    public function __isset($key)
-    {
-        return isset($this->$key);
-    }
-
-    /**
-     * Allow read access to immutable object properties
-     *
-     * @param string $key
-     *
-     * @return mixed
-     */
-    public function __get($key)
-    {
-        return $this->$key;
-    }
-
-    /**
-     * Protects against the object being modified
-     *
-     * @param string $key
-     * @param mixed  $value
-     *
-     * @return void
-     *
-     * @throws \RuntimeException
-     */
-    public function __set($key, $value)
-    {
-        throw new RuntimeException(sprintf(
-            'Modification of immutable object `%s` is not allowed',
-            get_class($this)
-        ));
-    }
-
-    /**
-     * Protects against the object being modified
-     *
-     * @param string $key
-     *
-     * @return void
-     *
-     * @throws \RuntimeException
-     */
-    public function __unset($key)
-    {
-        throw new RuntimeException(sprintf(
-            'Modification of immutable object `%s` is not allowed',
-            get_class($this)
-        ));
     }
 }

--- a/src/Traits/ProtectedValueObjectTrait.php
+++ b/src/Traits/ProtectedValueObjectTrait.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Equip\Data\Traits;
+
+use RuntimeException;
+
+trait ProtectedValueObjectTrait
+{
+    /**
+     * Checks if a property is defined in the object
+     *
+     * This will return `false` if the value is `null`! To check if a value
+     * exists in the object, use `has()`.
+     *
+     * @param string $key
+     *
+     * @return boolean
+     */
+    public function __isset($key)
+    {
+        return isset($this->$key);
+    }
+
+    /**
+     * Allow read access to immutable object properties
+     *
+     * @param string $key
+     *
+     * @return mixed
+     */
+    public function __get($key)
+    {
+        return $this->$key;
+    }
+
+    /**
+     * Protects against the object being modified
+     *
+     * @param string $key
+     * @param mixed  $value
+     *
+     * @return void
+     *
+     * @throws \RuntimeException
+     */
+    public function __set($key, $value)
+    {
+        throw new RuntimeException(sprintf(
+            'Modification of immutable object `%s` is not allowed',
+            get_class($this)
+        ));
+    }
+
+    /**
+     * Protects against the object being modified
+     *
+     * @param string $key
+     *
+     * @return void
+     *
+     * @throws \RuntimeException
+     */
+    public function __unset($key)
+    {
+        throw new RuntimeException(sprintf(
+            'Modification of immutable object `%s` is not allowed',
+            get_class($this)
+        ));
+    }
+}


### PR DESCRIPTION
Having a separate trait for protected magic methods is useful when we
want to have a value object without array-based value manipulation.
